### PR TITLE
chore(ai/hermes): add kopia backup for hermes data

### DIFF
--- a/clusters/psb/apps/ai/hermes/ks.yaml
+++ b/clusters/psb/apps/ai/hermes/ks.yaml
@@ -8,6 +8,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: hermes
+  components:
+    - ../../../../components/kopiur/backup
   dependsOn:
     - name: litellm
       namespace: ai
@@ -15,6 +17,8 @@ spec:
       namespace: ai
     - name: conduwuit
       namespace: matrix
+    - name: kopiur
+      namespace: system
   interval: 1h
   path: ./clusters/psb/apps/ai/hermes/app
   postBuild:


### PR DESCRIPTION
## Changes

Add the shared kopiur/backup component to the hermes Kustomization, so the hermes PVC (/opt/data - hermes config, .env, E2EE store) is snapshotted to the NAS on the same schedule as the other apps.

## Notes

The component's restore-based PVC is a no-op here because the hermes PVC already exists (IfNotPresent), so existing data is untouched - only the SnapshotPolicy and SnapshotSchedule take effect.