### PR TITLE
feat(actual): add kanidm OIDC SSO

### DIFF
--- a/clusters/psb/apps/ai/hermes/app/helmrelease.yaml
+++ b/clusters/psb/apps/ai/hermes/app/helmrelease.yaml
@@ -47,8 +47,8 @@ spec:
               capabilities:
                 drop:
                   - ALL
-              runAsGroup:  2000
-              runAsUser:  2000
+              runAsGroup: 2000
+              runAsUser: 2000
           init:
             image:
               repository: docker.io/library/alpine
@@ -64,8 +64,8 @@ spec:
               capabilities:
                 drop:
                   - ALL
-              runAsGroup:  2000
-              runAsUser:  2000
+              runAsGroup: 2000
+              runAsUser: 2000
           install-tools:
             image:
               repository: nousresearch/hermes-agent
@@ -103,8 +103,8 @@ spec:
               capabilities:
                 drop:
                   - ALL
-              runAsGroup:  2000
-              runAsUser:  2000
+              runAsGroup: 2000
+              runAsUser: 2000
         containers:
           app:
             image:

--- a/clusters/psb/apps/downloads/prowlarr/ks.yaml
+++ b/clusters/psb/apps/downloads/prowlarr/ks.yaml
@@ -27,7 +27,7 @@ spec:
       KOPIUR_CLAIM: prowlarr-config
       OIDC_DISPLAY_NAME: Prowlarr
       OIDC_GROUP: admins
-      OIDC_SCOPES: '["openid", "profile"]'
+      OIDC_SCOPES: "[\"openid\", \"profile\"]"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/psb/apps/downloads/qbittorrent/ks.yaml
+++ b/clusters/psb/apps/downloads/qbittorrent/ks.yaml
@@ -28,7 +28,7 @@ spec:
       KOPIUR_CAPACITY: 2Gi
       OIDC_DISPLAY_NAME: qBittorrent
       OIDC_GROUP: admins
-      OIDC_SCOPES: '["openid", "profile"]'
+      OIDC_SCOPES: "[\"openid\", \"profile\"]"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/psb/apps/downloads/radarr/ks.yaml
+++ b/clusters/psb/apps/downloads/radarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
       KOPIUR_CAPACITY: 2Gi
       OIDC_DISPLAY_NAME: Radarr
       OIDC_GROUP: admins
-      OIDC_SCOPES: '["openid", "profile"]'
+      OIDC_SCOPES: "[\"openid\", \"profile\"]"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/psb/apps/downloads/sabnzbd/ks.yaml
+++ b/clusters/psb/apps/downloads/sabnzbd/ks.yaml
@@ -28,7 +28,7 @@ spec:
       KOPIUR_CLAIM: sabnzbd-config
       OIDC_DISPLAY_NAME: SABnzbd
       OIDC_GROUP: admins
-      OIDC_SCOPES: '["openid", "profile"]'
+      OIDC_SCOPES: "[\"openid\", \"profile\"]"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/psb/apps/downloads/sonarr/ks.yaml
+++ b/clusters/psb/apps/downloads/sonarr/ks.yaml
@@ -28,7 +28,7 @@ spec:
       KOPIUR_CLAIM: sonarr-config
       OIDC_DISPLAY_NAME: Sonarr
       OIDC_GROUP: admins
-      OIDC_SCOPES: '["openid", "profile"]'
+      OIDC_SCOPES: "[\"openid\", \"profile\"]"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/psb/apps/media/immich/ks.yaml
+++ b/clusters/psb/apps/media/immich/ks.yaml
@@ -32,7 +32,7 @@ spec:
       SUBDOMAIN: immich
       OIDC_DISPLAY_NAME: "Immich"
       OIDC_CALLBACK: /auth/login
-      OIDC_EXTRA_CALLBACKS: '["app.immich:///oauth-callback", "https://immich.nebular-grid.space/user-settings"]'
+      OIDC_EXTRA_CALLBACKS: "[\"app.immich:///oauth-callback\", \"https://immich.nebular-grid.space/user-settings\"]"
       OIDC_LEGACY_CRYPTO: "true"
       OIDC_CLAIM_MAPS: |
         {

--- a/clusters/psb/apps/selfhosted/actual/app/helmrelease.yaml
+++ b/clusters/psb/apps/selfhosted/actual/app/helmrelease.yaml
@@ -31,6 +31,19 @@ spec:
               ACTUAL_PORT: &httpPort 5006
               ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB: 80
               NODE_OPTIONS: --max-old-space-size=768
+              # Kanidm OIDC SSO
+              ACTUAL_OPENID_DISCOVERY_URL: https://idm.nebular-grid.space/oauth2/openid/actual/.well-known/openid-configuration
+              ACTUAL_OPENID_CLIENT_ID:
+                secretKeyRef:
+                  name: kanidm-actual-oidc
+                  key: client-id
+              ACTUAL_OPENID_CLIENT_SECRET:
+                secretKeyRef:
+                  name: kanidm-actual-oidc
+                  key: client-secret
+              ACTUAL_OPENID_SERVER_HOSTNAME: https://actual.nebular-grid.space
+              ACTUAL_OPENID_ENFORCE: "true"
+              ACTUAL_USER_CREATION_MODE: login
             probes:
               liveness:
                 enabled: true

--- a/clusters/psb/apps/selfhosted/actual/ks.yaml
+++ b/clusters/psb/apps/selfhosted/actual/ks.yaml
@@ -10,17 +10,23 @@ spec:
       app.kubernetes.io/name: actual
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/oidc
   dependsOn:
     - name: kopiur
       namespace: system
     - name: rook-ceph-cluster
       namespace: rook-ceph
+    - name: kanidm
+      namespace: security
   interval: 1h
   path: "./clusters/psb/apps/selfhosted/actual/app"
   postBuild:
     substitute:
       APP: actual
+      APP_NAMESPACE: selfhosted
       KOPIUR_CLAIM: actual-data
+      OIDC_DISPLAY_NAME: Actual Budget
+      OIDC_CALLBACK: /openid/callback
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/psb/components/oidc/base/ks.yaml
+++ b/clusters/psb/components/oidc/base/ks.yaml
@@ -47,7 +47,7 @@ spec:
       CUSTOM_STATE: ${q:='}${OIDC_CUSTOM_STATE:=}${q:='}
       emptyState: "{}"
       emptyArray: "[]"
-      defaultScopes: '["openid", "profile", "email", "groups"]'
+      defaultScopes: "[\"openid\", \"profile\", \"email\", \"groups\"]"
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
## Changes

Wire Actual Budget into kanidm for SSO login.

- Add the oidc component to the actual Kustomization, creating a kanidm OAuth2 client (callback `/openid/callback`)
- Inject actual-server's native OIDC env vars from the generated `kanidm-actual-oidc` secret
- Enable OIDC enforcement and automatic user creation

## Notes

The `kanidm-actual-oidc` Secret (keys `client-id`/`client-secret`) is populated by the kanidm-provision operator once this lands and flux reconciles. The first kanidm user to sign in becomes the Actual server owner.
