### PR TITLE
fix(actual): enable kanidm legacy crypto for RS256 id token

### DIFF
--- a/clusters/psb/apps/selfhosted/actual/ks.yaml
+++ b/clusters/psb/apps/selfhosted/actual/ks.yaml
@@ -27,6 +27,7 @@ spec:
       KOPIUR_CLAIM: actual-data
       OIDC_DISPLAY_NAME: Actual Budget
       OIDC_CALLBACK: /openid/callback
+      OIDC_LEGACY_CRYPTO: "true"
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Changes

Fix Actual Budget login failing with `openid-grant-failed` / `unexpected JWT alg received, expected RS256, got: ES256`.

Actual-server's openid-client library only accepts RS256 ID tokens, but kanidm defaults to ES256. Setting `OIDC_LEGACY_CRYPTO: "true"` on the actual client makes kanidm sign with RS256 (per-client, via `enableLegacyCrypto`).

## Notes

Other OIDC apps in the stack already use this flag (e.g. immich). One line, per-client only - does not affect other kanidm clients. After this lands and reconfigures, the existing kanidm `actual` oauth2 client will use RS256 and the ID token validates.
