### PR TITLE
fix(ci): grant automerge app token contents write permission

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -26,6 +26,7 @@ jobs:
           app-id: ${{ vars.TRASHBOT_APP_ID }}
           private-key: ${{ secrets.TRASHBOT_APP_PRIVATE_KEY }}
           permission-pull-requests: write
+          permission-contents: write
 
       - name: Enable Auto Merge (squash via gh)
         env:


### PR DESCRIPTION
## Changes

The auto-merge workflow's TRASHBOT app token was missing `contents: write`, so the squash merge via gh was rejected. Grant that permission so the bot can merge.\n\n## Notes\n\nRequires the TRASHBOT_APP_ID app to have contents write installed in the repo.