### PR TITLE
fix(ai): run signal-cli native daemon for Hermes

### DIFF
--- a/clusters/psb/apps/ai/signal-cli/app/helmrelease.yaml
+++ b/clusters/psb/apps/ai/signal-cli/app/helmrelease.yaml
@@ -12,11 +12,13 @@ spec:
   values:
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
-        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000
         fsGroup: 2000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
     controllers:
       signal-cli:
         annotations:
@@ -25,23 +27,46 @@ spec:
         containers:
           app:
             image:
-              repository: docker.io/bbernhard/signal-cli-rest-api
-              tag: "0.92"
+              repository: ghcr.io/asamk/signal-cli
+              tag: "0.14.7"
+            command:
+              - /bin/sh
+              - -c
+            args:
+              # multi-account mode: serves whatever accounts are linked in the config dir
+              - /opt/signal-cli/bin/signal-cli --config=/var/lib/signal-cli daemon --http 0.0.0.0:8080
             env:
-              MODE: json-rpc
               TZ: Europe/Prague
-              # entrypoint remaps its built-in signal-api user to match fsGroup; repo convention is 2000
-              SIGNAL_CLI_UID: "2000"
-              SIGNAL_CLI_GID: "2000"
             probes:
               readiness:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /api/v1/check
                     port: 8080
                   periodSeconds: 5
-                  timeoutSeconds: 5
+                  initialDelaySeconds: 10
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/check
+                    port: 8080
+                  periodSeconds: 30
+                  initialDelaySeconds: 10
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/check
+                    port: 8080
+                  periodSeconds: 10
+                  initialDelaySeconds: 10
                   failureThreshold: 30
             resources:
               requests:
@@ -51,26 +76,25 @@ spec:
                 memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
               capabilities:
                 drop:
                   - ALL
-                add:
-                  # entrypoint runs usermod/groupmod/chown then setpriv down to signal-api (uid 2000)
-                  - CHOWN
-                  - SETUID
-                  - SETGID
     service:
       app:
         controller: signal-cli
         ports:
-          jsonrpc:
+          http:
             port: 8080
     persistence:
       data:
         enabled: true
         type: persistentVolumeClaim
         existingClaim: "{{ .Release.Name }}"
-        advancedMounts:
-          signal-cli:
-            app:
-              - path: /home/.local/share/signal-cli
+        globalMounts:
+          - path: /var/lib/signal-cli
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp


### PR DESCRIPTION
## Why
Hermes v2026.8.3's Signal adapter is hard-wired to signal-cli's **native HTTP daemon** (`/api/v1/check`, `/api/v1/events` SSE, `/api/v1/rpc`). The bbernhard `signal-cli-rest-api` wrapper serves only `/v1/*`, so Hermes logged `Signal: health check failed (status 404)` and never connected.

No Hermes upgrade exists (v2026.8.3 is latest; the hermes PR migrating to signal-cli-rest-api v0.99 was not merged).

## Change
- image `docker.io/bbernhard/signal-cli-rest-api:0.92` -> `ghcr.io/asamk/signal-cli:0.14.7`
- run `signal-cli --config=/var/lib/signal-cli daemon --http 0.0.0.0:8080` (multi-account mode)
- reuses the existing `signal-cli` PVC - the linked account is adopted, no re-link
- **runs non-root**: uid/gid/fsGroup 999, `runAsNonRoot: true`, drop ALL caps, `readOnlyRootFilesystem: true`, seccomp RuntimeDefault
- probes now hit `/api/v1/check` (matches Hermes; liveness/readiness/startup)
- service stays `signal-cli:8080`, so Hermes `SIGNAL_HTTP_URL` is unchanged

## Notes
- bbernhard root-bootstrap (usermod/setpriv) gone; the native daemon serves the `/api/v1/*` endpoints itself
- #1093 (bbernhard 0.100 image bump) closed as superseded

## Verify
- pod ready; `/v1/check` responds 200; Hermes signal gateway connects (no more 404 / reconnect loop)
- yamllint passes; single-file diff
