### PR TITLE
feat(oidc): rename kanidm users group to adults, add children access

### DIFF
--- a/clusters/psb/apps/ai/open-webui/app/helmrelease.yaml
+++ b/clusters/psb/apps/ai/open-webui/app/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
                     key: client-secret
               ENABLE_OAUTH_ROLE_MANAGEMENT: "true"
               OAUTH_ROLES_CLAIM: groups
-              OAUTH_ALLOWED_ROLES: users@idm.nebular-grid.space,admins@idm.nebular-grid.space
+              OAUTH_ALLOWED_ROLES: adults@idm.nebular-grid.space,admins@idm.nebular-grid.space
             envFrom:
               - secretRef:
                   name: open-webui-secret

--- a/clusters/psb/apps/media/immich/ks.yaml
+++ b/clusters/psb/apps/media/immich/ks.yaml
@@ -38,7 +38,7 @@ spec:
           "roles": {
             "joinType": "array",
             "valuesByGroup": {
-              "users@idm.nebular-grid.space": ["user"],
+              "adults@idm.nebular-grid.space": ["user"],
               "admins@idm.nebular-grid.space": ["admin"]
             }
           }

--- a/clusters/psb/apps/media/jellyfin/ks.yaml
+++ b/clusters/psb/apps/media/jellyfin/ks.yaml
@@ -35,12 +35,17 @@ spec:
       OIDC_CALLBACK: /sso/OID/redirect/kanidm
       OIDC_ORIGIN: /sso/OID/start/kanidm
       OIDC_SHORT_USERNAME: "true"
+      OIDC_SCOPE_MAPS: |
+        {
+          "children": ["openid", "profile", "email", "groups"]
+        }
       OIDC_CLAIM_MAPS: |
         {
           "roles": {
             "joinType": "array",
             "valuesByGroup": {
-              "users@idm.nebular-grid.space": ["user"],
+              "adults@idm.nebular-grid.space": ["user"],
+              "children@idm.nebular-grid.space": ["user"],
               "admins@idm.nebular-grid.space": ["admin"]
             }
           }

--- a/clusters/psb/components/oidc/base/kanidm/configmap.yaml
+++ b/clusters/psb/components/oidc/base/kanidm/configmap.yaml
@@ -50,7 +50,7 @@ data:
         "oauth2": {
           "${APP}": {
             "scopeMaps": {
-              "users": [],
+              "adults": [],
               "admins": []
             }
           }

--- a/clusters/psb/components/oidc/base/ks.yaml
+++ b/clusters/psb/components/oidc/base/ks.yaml
@@ -33,7 +33,7 @@ spec:
       LEGACY_CRYPTO: ${q:="}${OIDC_LEGACY_CRYPTO:=false}${q:="}
       DISABLE_PKCE: ${q:="}${OIDC_DISABLE_PKCE:=false}${q:="}
 
-      GROUP: "${OIDC_GROUP:=users}"
+      GROUP: "${OIDC_GROUP:=adults}"
       SCOPES: ${q:='}${OIDC_SCOPES:=}${q:='}
 
       SCOPE_MAPS: ${q:='}${OIDC_SCOPE_MAPS:=}${q:='}


### PR DESCRIPTION
## Changes

Rename the shared kanidm OIDC group `users` to `adults` and add a `children` group, so child accounts get per-app access without opening the rest of the family apps.

- Default OIDC scope group is now `adults`.
- Jellyfin gains a `children` scope map + role claim so `children` members can log in.
- Immich and open-webui role claims updated from `users` to `adults`.

## Notes

Needs the kanidm groups created on the live instance first: `adults` (petr, anet) and `children` (oliver, elisa). `admins` members unchanged.