### PR TITLE
fix(oidc): wrap REDIRECTS substitute to restore Kustomization validation

### DIFF
--- a/clusters/psb/components/oidc/base/ks.yaml
+++ b/clusters/psb/components/oidc/base/ks.yaml
@@ -26,7 +26,7 @@ spec:
 
       ORIGIN: ${OIDC_ORIGIN:=/}
       EXTRA_CALLBACKS: ${q:='}${OIDC_EXTRA_CALLBACKS:=}${q:='}
-      REDIRECTS: ${OIDC_REDIRECTS:=}
+      REDIRECTS: ${q:='}${OIDC_REDIRECTS:=}${q:='}
       SHORT_USERNAME: ${q:="}${OIDC_SHORT_USERNAME:=false}${q:="}
 
       LOCALHOST: ${q:="}${OIDC_LOCALHOST:=false}${q:="}


### PR DESCRIPTION
## Changes

`REDIRECTS` is the only `postBuild.substitute` variable in the kanidm oidc base that is not wrapped in quote guards. When app-template renders the per-app `kanidm-*-oidc` Kustomizations it emits `REDIRECTS` as JSON `null` (apps without redirects) or a JSON array (immich), which fails Flux validation (`must be of type string`).

This failure has been blocking the app Kustomizations from reconciling for a long time, and currently stops the kanidm group re-point from propagating.

Wrap `REDIRECTS` in the same quote guards used by `SCOPES`, `CLAIM_MAPS`, etc.

## Notes

Verify the oidc Kustomizations reconcile cleanly and the `originUrl` still renders correctly (empty `REDIRECTS` falls back to the `DOMAIN`+`CALLBACK` default in `state.json`).