### PR TITLE
branding: apply nebular grid theme to kanidm and paperless

### DIFF
--- a/clusters/psb/apps/security/kanidm/app/configmap.yaml
+++ b/clusters/psb/apps/security/kanidm/app/configmap.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-branding
+data:
+  override.css: |-
+    /* Nebular Grid branding - cyberdream palette from the logo.
+       Kanidm UI is Bootstrap-driven; override its CSS custom properties. */
+    :root {
+      --bs-body-bg: #16181a;
+      --bs-body-color: #ffffff;
+      --bs-primary: #5ef1ff;
+      --bs-primary-rgb: 94, 241, 255;
+      --bs-link-color: #5ea1ff;
+      --bs-emphasis-color: #ffffff;
+    }

--- a/clusters/psb/apps/security/kanidm/app/helmrelease.yaml
+++ b/clusters/psb/apps/security/kanidm/app/helmrelease.yaml
@@ -146,6 +146,15 @@ spec:
           provision:
             app:
               - path: /data/icons
+      branding:
+        type: configMap
+        name: kanidm-branding
+        advancedMounts:
+          kanidm:
+            app:
+              - path: /hpkg/override.css
+                subPath: override.css
+                readOnly: true
     rbac:
       roles:
         kanidm-write-secret:

--- a/clusters/psb/apps/security/kanidm/app/kustomization.yaml
+++ b/clusters/psb/apps/security/kanidm/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./ocirepository.yaml
   - ./certificate.yaml
   - ./backendtlspolicy.yaml

--- a/clusters/psb/apps/selfhosted/paperless/app/helmrelease.yaml
+++ b/clusters/psb/apps/selfhosted/paperless/app/helmrelease.yaml
@@ -46,21 +46,6 @@ spec:
               PAPERLESS_DATA_DIR: /data/local/data
               PAPERLESS_EXPORT_DIR: /data/nas/export
               PAPERLESS_MEDIA_ROOT: /data/local/media
-              # Configure folder importer
-              PAPERLESS_CONSUMER_POLLING: "60"
-              PAPERLESS_CONSUMER_RECURSIVE: "true"
-              PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: "true"
-              # Configure OCR
-              PAPERLESS_OCR_LANGUAGES:
-                valueFrom:
-                  secretKeyRef:
-                    name: paperless-secret
-                    key: PAPERLESS_OCR_LANGUAGE
-              PAPERLESS_OCR_LANGUAGE:
-                valueFrom:
-                  secretKeyRef:
-                    name: paperless-secret
-                    key: PAPERLESS_OCR_LANGUAGE
               PAPERLESS_REDIS: redis://paperless-dragonfly.selfhosted.svc.cluster.local:6379
               # Configure user permissions
               USERMAP_UID: "2000"


### PR DESCRIPTION
## Changes

Bring the Nebular Grid cyberdream branding to the two self-hosted apps with real branding hooks.

- Kanidm: set display name and site logo (set via CLI), add an override.css configmap mounted at /hpkg/override.css to theme the bootstrap UI with the cyberdream palette.
- Paperless: brand via UI instead; remove the env vars now handled in the web UI (title, logo, ocr language, consumption options).

## Notes

- Kanidm site image and display name were set live against the running instance, not in this diff; this PR wires the CSS theme so the changed name/logo/colors all apply after reconcile.
- Paperless logo file needs to sit on the paperless-data PVC at media/logo/ per the app's security check.