### PR TITLE
ci: align job names with branch ruleset status checks

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   code-quality:
-    name: code-quality
+    name: Code Quality
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
         run: mise run check
 
   tests:
-    name: tests
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   pr-conventions:
-    name: Validate title and label
+    name: Validate PR Conventions
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:


### PR DESCRIPTION
## Changes

Rename workflow job names so the CI check contexts match the branch ruleset required status checks:
- code-quality -> Code Quality
- tests -> Run Tests
- Validate title and label -> Validate PR Conventions

The rulesets require these exact context names, so the checks must produce them for PRs to merge.