### PR TITLE
chore: add repository CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @trash-panda-v91-beta


### PR DESCRIPTION
## Changes

Own all repo paths as trash-panda-v91-beta so PRs require review instead of merging unreviewed.