### PR TITLE
fix(donetick): disable pkce for kanidm oidc client

### DIFF
--- a/clusters/psb/apps/selfhosted/donetick/ks.yaml
+++ b/clusters/psb/apps/selfhosted/donetick/ks.yaml
@@ -30,6 +30,9 @@ spec:
       KOPIUR_CAPACITY: 1Gi
       OIDC_DISPLAY_NAME: Donetick
       OIDC_CALLBACK: /auth/oauth2
+      # Donetick's OAuth2 client (v0.1.76) doesn't implement PKCE; allow the
+      # plain code flow so Kanidm doesn't reject the authorize request.
+      OIDC_DISABLE_PKCE: "true"
       OIDC_SCOPE_MAPS: "{\"children\": [], \"admins\": []}"
   prune: true
   sourceRef:


### PR DESCRIPTION
Kanidm rejects Donetick's OIDC login with `invalid_request: No PKCE code challenge was provided with client in enforced PKCE mode`. Donetick v0.1.76 doesn't implement PKCE (plain code flow), so the authorize request carries no `code_challenge` and Kanidm refuses it.

Sets `OIDC_DISABLE_PKCE: "true"` on the donetick ks.yaml so the oidc component re-provisions the Kanidm client with `allowInsecureClientDisablePkce` enabled, accepting the non-PKCE flow.

Follow-up to #1144, which registered the oidc component but left PKCE enforced.