### PR TITLE
fix(donetick): correct oauth2 userinfo env var name

### DIFF
--- a/clusters/psb/apps/selfhosted/donetick/app/helmrelease.yaml
+++ b/clusters/psb/apps/selfhosted/donetick/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
               DT_OAUTH2_REDIRECT_URL: https://donetick.nebular-grid.space/auth/oauth2
               DT_OAUTH2_AUTH_URL: https://idm.nebular-grid.space/ui/oauth2
               DT_OAUTH2_TOKEN_URL: https://idm.nebular-grid.space/oauth2/token
-              DT_OAUTH2_INFO_URL: https://idm.nebular-grid.space/oauth2/openid/donetick/userinfo
+              DT_OAUTH2_USER_INFO_URL: https://idm.nebular-grid.space/oauth2/openid/donetick/userinfo
               DT_OAUTH2_CLIENT_ID:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Donetick stopped failing on PKCE (from #1146) but the login then errored client-side. The pod log showed `failed to get claims errGet "": unsupported protocol scheme ""` - the userinfo fetch hit an empty URL.

Donetick v0.1.76 reads the userinfo endpoint from `DT_OAUTH2_USER_INFO_URL` (its own `config/selfhosted.env`), but the HelmRelease set `DT_OAUTH2_INFO_URL`, which maps to no config field, so `UserInfoURL` stayed empty and the callback panicked.

Renames the env var to `DT_OAUTH2_USER_INFO_URL`. Same value, correct key.