### PR TITLE
fix(donetick): register mobile OAuth redirect for Kanidm SSO

### DIFF
--- a/clusters/psb/apps/selfhosted/donetick/ks.yaml
+++ b/clusters/psb/apps/selfhosted/donetick/ks.yaml
@@ -30,6 +30,9 @@ spec:
       KOPIUR_CAPACITY: 1Gi
       OIDC_DISPLAY_NAME: Donetick
       OIDC_CALLBACK: /auth/oauth2
+      # Mobile is a Capacitor app that redirects to the donetick:// deep link;
+      # register it alongside the web callback so Kanidm accepts it on iOS/Android.
+      OIDC_REDIRECTS: "[\"https://donetick.nebular-grid.space/auth/oauth2\", \"donetick://auth/oauth2\"]"
       # Donetick's OAuth2 client (v0.1.76) doesn't implement PKCE; allow the
       # plain code flow so Kanidm doesn't reject the authorize request.
       OIDC_DISABLE_PKCE: "true"


### PR DESCRIPTION
Registers the mobile deep-link callback in the Kanidm OIDC client so SSO works from the iOS/Android app.

On phones Donetick (a Capacitor app) uses `donetick://auth/oauth2` as its OAuth redirect URI instead of the web `https://donetick.nebular-grid.space/auth/oauth2`. Kanidm only had the web redirect registered, so it rejected the phone callback with `invalid_grant ... does not match the redirect URI`.

Adds `OIDC_REDIRECTS` listing both callbacks, same pattern paperless (`x-paperless://`) and immich (`app.immich:///`) already use. Existing sessions unaffected; new logins on phones pick it up after Flux reconciles the Kanidm client.