### PR TITLE
feat(ai): deploy donetick MCP server via litellm gateway

### DIFF
--- a/clusters/psb/apps/ai/kustomization.yaml
+++ b/clusters/psb/apps/ai/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./memini/ks.yaml
   - ./hermes/ks.yaml
   - ./mcp/searxng-mcp/ks.yaml
+  - ./mcp/donetick-mcp/ks.yaml
   - ./mcp/context7-mcp/ks.yaml
   - ./mcp/ha-mcp/ks.yaml
   - ./mcp/grafana-mcp/ks.yaml

--- a/clusters/psb/apps/ai/mcp/donetick-mcp/app/externalsecret.yaml
+++ b/clusters/psb/apps/ai/mcp/donetick-mcp/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# API token from Donetick (settings > Advanced > API). Create a 1Password field
+# `api_token` on the `donetick` item.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: donetick-mcp
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: donetick-mcp-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: DONETICK_API_TOKEN
+      remoteRef:
+        key: donetick
+        property: api_token

--- a/clusters/psb/apps/ai/mcp/donetick-mcp/app/kustomization.yaml
+++ b/clusters/psb/apps/ai/mcp/donetick-mcp/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/clusters/psb/apps/ai/mcp/donetick-mcp/app/mcpserver.yaml
+++ b/clusters/psb/apps/ai/mcp/donetick-mcp/app/mcpserver.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmcpserver_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMMCPServer
+metadata:
+  name: donetick-mcp
+spec:
+  alias: donetick_mcp
+  transport: http
+  workload:
+    image: ghcr.io/trash-panda-v91-beta/donetick-mcp:latest@sha256:ac678b3a0bcafe6049d272d06cd0003b779cc4071862da23a2e74f3ce49c2168
+    port: 8000
+    path: /mcp
+    env:
+      - name: DONETICK_BASE_URL
+        value: https://donetick.nebular-grid.space
+      - name: DONETICK_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: donetick-mcp-secret
+            key: DONETICK_API_TOKEN
+      # FastMCP serves streamable-http from FASTMCP_* env vars - no code change
+      - name: FASTMCP_TRANSPORT
+        value: streamable-http
+      - name: FASTMCP_HOST
+        value: 0.0.0.0
+      - name: FASTMCP_PORT
+        value: "8000"
+      - name: FASTMCP_STREAMABLE_HTTP_PATH
+        value: /mcp

--- a/clusters/psb/apps/ai/mcp/donetick-mcp/app/mcpserver.yaml
+++ b/clusters/psb/apps/ai/mcp/donetick-mcp/app/mcpserver.yaml
@@ -13,7 +13,10 @@ spec:
     path: /mcp
     env:
       - name: DONETICK_BASE_URL
-        value: https://donetick.nebular-grid.space
+        value: http://donetick.selfhosted.svc.cluster.local:2021
+      # internal traffic is plaintext http; opt out of the https-only default
+      - name: ALLOW_INSECURE_HTTP
+        value: "true"
       - name: DONETICK_API_TOKEN
         valueFrom:
           secretKeyRef:

--- a/clusters/psb/apps/ai/mcp/donetick-mcp/app/mcpserver.yaml
+++ b/clusters/psb/apps/ai/mcp/donetick-mcp/app/mcpserver.yaml
@@ -8,7 +8,7 @@ spec:
   alias: donetick_mcp
   transport: http
   workload:
-    image: ghcr.io/trash-panda-v91-beta/donetick-mcp:latest@sha256:ac678b3a0bcafe6049d272d06cd0003b779cc4071862da23a2e74f3ce49c2168
+    image: ghcr.io/trash-panda-v91-beta/donetick-mcp:v1.1.0@sha256:0ba1eaa21d17a9ac4ea651126da28f0163c40e77edf972761ef4ca2132be3cdf
     port: 8000
     path: /mcp
     env:

--- a/clusters/psb/apps/ai/mcp/donetick-mcp/ks.yaml
+++ b/clusters/psb/apps/ai/mcp/donetick-mcp/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: donetick-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: donetick-mcp
+  dependsOn:
+    - name: litellm-operator
+      namespace: ai
+  interval: 1h
+  path: ./clusters/psb/apps/ai/mcp/donetick-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Deploys the donetick-mcp server in the ai namespace as a LiteLLMMCPServer, same pattern as the other /ai/mcp apps (actual-mcp, ha-mcp). Exposes it through the litellm gateway as donetick_mcp.

- LiteLLMMCPServer: donetick-mcp v1.1.0 (pinned by digest), streamable-http on port 8000 at /mcp (FastMCP reads FASTMCP_* env vars)
- Points at the in-cluster service: http://donetick.selfhosted.svc.cluster.local:2021, with ALLOW_INSECURE_HTTP=true (opt-in from v1.1.0)
- ExternalSecret: DONETICK_API_TOKEN pulled from the 1Password donetick item (api_token field)
- Registers the Flux Kustomization in ai/kustomization.yaml

Verified: v1.1.0 image serves a valid streamable-http handshake and accepts the plaintext internal URL; kustomize build + yamllint pass.