### PR TITLE
ci(renovate): run once per day instead of hourly

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -4,7 +4,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 6 * * *
   workflow_dispatch:
     inputs:
       dryRun:


### PR DESCRIPTION
Renovate was scheduled every hour. Running once per day at 06:00 UTC is enough for this repo and cuts the noise/load.

One-line change to the cron expression in .github/workflows/renovate.yaml.