### PR TITLE
fix(renovate): disable docker digest pinning to clear errored pin branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,12 @@
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "packageRules": [
     {
+      "description": "Disable docker digest pinning - resolving digests for every image (incl. private/self-hosted registries) fails and poisons the pinned branches with update failures",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
+    },
+    {
       "description": "Configure Emby versioning",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/home-operations/emby"],


### PR DESCRIPTION
## Root cause

The three errored branches (renovate/pin-dependencies, renovate/kubernetes, renovate/flux-operator) all fail with "Error updating branch: update failure" on every run. A debug run shows they are all `pinDigest` branches - Renovate trying to add `@sha256:` digests to every unpinned image in one giant branch.

The earlier fix in `.renovate/overrides.json` (disable digest pinning for k8s/talos/flux images) never worked: it matches `matchUpdateTypes: ["digest"]`, but these branches are `pinDigest`, a different Renovate update type. So the exclusion never applied and the branches kept erroring.

## Fix

Disable the `pinDigest` update type for the docker datasource repo-wide. This stops all three failing pin branches (plus their digest-resolution failures against private/self-hosted registries reporting "No docker auth found").

## Behavior change

Renovate will no longer auto-add digests to unpinned images. Existing already-pinned digests are untouched and their `digest` updates still work (that is a separate update type). If you want digest pinning back, we need to debug why digest resolution fails for the private registries first.
