### PR TITLE
fix(renovate): pin k8s images, keep them updating, narrow helm-values manager

### DIFF
--- a/.renovate/overrides.json
+++ b/.renovate/overrides.json
@@ -14,9 +14,9 @@
       "overridePackageName": "ghcr.io/siderolabs/installer"
     },
     {
-      "description": "Disable digest pinning for date-versioned system images (k8s, talos, flux-operator) - these don't resolve cleanly for digest pinning and cause pin-branch errors",
+      "description": "Disable digest pinning for images that don't resolve cleanly (date-versioned k8s/talos/flux system images) or need auth (self-hosted registries) - pinning them fails the whole pinned branch",
       "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["digest"],
+      "matchUpdateTypes": ["pinDigest"],
       "matchPackageNames": [
         "registry.k8s.io/kube-apiserver",
         "registry.k8s.io/kube-controller-manager",
@@ -24,7 +24,9 @@
         "registry.k8s.io/kube-scheduler",
         "ghcr.io/siderolabs/kubelet",
         "ghcr.io/siderolabs/installer",
-        "/controlplaneio-fluxcd/"
+        "/controlplaneio-fluxcd/",
+        "/forgejo\\.ellis\\.link/",
+        "/erwanleboucher\\.dev/"
       ],
       "enabled": false
     }

--- a/clusters/psb/talos/machineconfig.yaml.j2
+++ b/clusters/psb/talos/machineconfig.yaml.j2
@@ -64,7 +64,7 @@ machine:
         - net.ipv6.conf.*
       maxPods: 150
       serializeImagePulls: false
-    image: ghcr.io/siderolabs/kubelet:v1.36.3
+    image: ghcr.io/siderolabs/kubelet:v1.36.3@sha256:ecc3184de027c8656c697e35aa889f625d525cc86c5e5a83c7ac6486535dd8bc
     nodeIP:
       validSubnets:
         - 10.1.1.0/24
@@ -130,7 +130,7 @@ cluster:
     key: "op://NebularGrid/6i7sewsv3lus3qxpwddknc7jem/aggregator ca key"
   allowSchedulingOnControlPlanes: true
   apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.36.3
+    image: registry.k8s.io/kube-apiserver:v1.36.3@sha256:b4bc06c81fd76f81174e6c19ddacf477acdf1583e7a5846ebbd513493aef6e43
     extraArgs:
       enable-aggregator-routing: "true"
       feature-gates: MutatingAdmissionPolicy=true,HPAScaleToZero=true
@@ -141,7 +141,7 @@ cluster:
       - psb.internal
     disablePodSecurityPolicy: true
   controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.36.3
+    image: registry.k8s.io/kube-controller-manager:v1.36.3@sha256:ed56454bf514916079a227f5765b64524fde52106dfcc52978b28634765b78b8
     extraArgs:
       bind-address: 0.0.0.0
       feature-gates: HPAScaleToZero=true
@@ -157,7 +157,7 @@ cluster:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.3
+    image: registry.k8s.io/kube-proxy:v1.36.3@sha256:919d710a0e8bf2bd67d347e512e88205cb82a53a48ab6ff380d014406300ad1b
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
@@ -178,7 +178,7 @@ cluster:
           schedulerName: default-scheduler
     extraArgs:
       bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-scheduler:v1.36.3
+    image: registry.k8s.io/kube-scheduler:v1.36.3@sha256:128fc07d278d64c4f2cce416ed0a9f37b23a30cdde6f97873d18c9c78e259df4
   secretboxEncryptionSecret: "op://NebularGrid/6i7sewsv3lus3qxpwddknc7jem/secretbox encryption secret"
   serviceAccount:
     key: "op://NebularGrid/6i7sewsv3lus3qxpwddknc7jem/service account"

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,7 @@
     "enabled": true
   },
   "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "ignorePaths": ["clusters/psb/talos/machineconfig.yaml.j2"],
   "packageRules": [
     {
       "description": "Configure Emby versioning",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "managerFilePatterns": ["/^clusters/.+\\.yaml(?:\\.j2)?$/"]
   },
   "helm-values": {
-    "managerFilePatterns": ["/^clusters/.+\\.yaml(?:\\.j2)?$/"]
+    "managerFilePatterns": ["/^clusters/(?!psb/talos/).+\\.yaml(?:\\.j2)?$/"]
   },
   "kubernetes": {
     "managerFilePatterns": ["/^clusters/.+\\.yaml(?:\\.j2)?$/"]
@@ -21,7 +21,6 @@
     "enabled": true
   },
   "minimumReleaseAgeBehaviour": "timestamp-optional",
-  "ignorePaths": ["clusters/psb/talos/machineconfig.yaml.j2"],
   "packageRules": [
     {
       "description": "Configure Emby versioning",


### PR DESCRIPTION
## Goal

k8s system images (`kube-apiserver`, `kubelet`, etc.) must **keep updating**, and all images from the pin-problem registries should be **pinned**.

## Changes

1. **`clusters/psb/talos/machineconfig.yaml.j2`** - pinned the 5 k8s system images with their resolved `@sha256:` digests (kubelet, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler). Pinned they are reproducible, get no failing `pinDigest` branch, and still update - Renovate bumps the version tag and digest together.

2. **`renovate.json`** - instead of `ignorePaths` (which dropped k8s update detection entirely), narrowed only the `helm-values` manager to skip `clusters/psb/talos/`. The `kubernetes` and `flux` managers still parse the machineconfig, so k8s image updates keep working, but the `helm-values` manager stops throwing `YAMLParseError` on the Jinja template.

3. **`.renovate/overrides.json`** - the earlier pin exclusion now matches `pinDigest` (the real update type) and covers the self-hosted registries (`forgejo.ellis.link`, `registry.erwanleboucher.dev`) that can't resolve digests without auth.

Verified the 5 k8s digests resolve correctly against the registries before pinning.

Note: the flux-operator and memini references are OCI helm charts, not runtime image tags - left those to chart-version updates rather than digest-pinning (Flux manages their digests).
