### PR TITLE
chore(container): pin OCI helm chart digests

### DIFF
--- a/clusters/psb/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/clusters/psb/apps/kube-system/cilium/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 1.18.6
+    digest: sha256:795a953d8a8d79d9d06e3b7aa0e2207f8863b5e4820b22e28b73c726e9095491
   url: oci://ghcr.io/home-operations/charts-mirror/cilium

--- a/clusters/psb/apps/kube-system/intel-gpu-resource-driver/app/ocirepository.yaml
+++ b/clusters/psb/apps/kube-system/intel-gpu-resource-driver/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.11.0
+    digest: sha256:a927938c242e39787e87d0c85d1733f5f4d35c1e581cee758fc9d0ac8f76f30b
   url: oci://ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gpu-resource-driver-chart

--- a/clusters/psb/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/clusters/psb/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 3.13.1
+    digest: sha256:9dfceeb7f001232602ab4bdd3fd2e61ac50da7081acf5518910276b7fe3a932d
   url: oci://ghcr.io/home-operations/charts-mirror/metrics-server

--- a/clusters/psb/apps/media/immich/app/ocirepository.yaml
+++ b/clusters/psb/apps/media/immich/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.13.1
+    digest: sha256:b8e890d0d9804759c6b6f3e5f9a850512ca09b9ccc6d137a2f85cbf761981bd1
   url: oci://ghcr.io/immich-app/immich-charts/immich

--- a/clusters/psb/apps/network/external-dns/cloudflare/ocirepository.yaml
+++ b/clusters/psb/apps/network/external-dns/cloudflare/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
+    digest: sha256:ce2e532b5d2d61b676fb01e04343d1f3433e752c90580a75a853aba6ac72b3aa
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns

--- a/clusters/psb/apps/network/external-dns/unifi/ocirepository.yaml
+++ b/clusters/psb/apps/network/external-dns/unifi/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
+    digest: sha256:ce2e532b5d2d61b676fb01e04343d1f3433e752c90580a75a853aba6ac72b3aa
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns

--- a/clusters/psb/apps/observability/grafana/operator/ocirepository.yaml
+++ b/clusters/psb/apps/observability/grafana/operator/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 5.24.0
+    digest: sha256:4f69cdaecfed2cc61d4e5f4a8e7142795e9b00997e4bcbd37a8c154a225a2f1f
   url: oci://ghcr.io/grafana/helm-charts/grafana-operator

--- a/clusters/psb/apps/observability/node-exporter/app/ocirepository.yaml
+++ b/clusters/psb/apps/observability/node-exporter/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 4.56.1
+    digest: sha256:a6f82b5f8aa94d9825740d7d425fe76dd81a28f9918ff620bfc44e9c4d674aa6
   url: oci://ghcr.io/prometheus-community/charts/prometheus-node-exporter

--- a/clusters/psb/apps/observability/prometheus-adapter/app/ocirepository.yaml
+++ b/clusters/psb/apps/observability/prometheus-adapter/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 5.3.0
+    digest: sha256:021eaa13e372ad42c59b50ebe4a0cd9cc3eaa5c21c2df2acb1b8bba44c1b1110
   url: oci://ghcr.io/prometheus-community/charts/prometheus-adapter

--- a/clusters/psb/apps/observability/silence-operator/app/ocirepository.yaml
+++ b/clusters/psb/apps/observability/silence-operator/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.20.1
+    digest: sha256:93883e6415571a734525369c58d9c21f57fee3ad61b30a88b6fff0222c3260f9
   url: oci://gsoci.azurecr.io/charts/giantswarm/silence-operator

--- a/clusters/psb/apps/observability/smartctl-exporter/app/ocirepository.yaml
+++ b/clusters/psb/apps/observability/smartctl-exporter/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.17.1
+    digest: sha256:3b205562ffcb1fc6228c9216b3f1b1d6451e647cb73d02548c402e780ac8289f
   url: oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter

--- a/clusters/psb/apps/observability/victoria-logs/app/ocirepository.yaml
+++ b/clusters/psb/apps/observability/victoria-logs/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.13.9
+    digest: sha256:e32b6fbe50188a6b904642ae6686646ee708913bca494b558296136759225bc1
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-single

--- a/clusters/psb/apps/observability/victoria-logs/collector/ocirepository.yaml
+++ b/clusters/psb/apps/observability/victoria-logs/collector/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.3.7
+    digest: sha256:2ec5d41cbc0309ef0cfa10945e5b7773298ba25b8a67a28296f888b8adb2b0ba
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector

--- a/clusters/psb/apps/openebs/openebs/app/ocirepository.yaml
+++ b/clusters/psb/apps/openebs/openebs/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 4.5.1
+    digest: sha256:b74c651822ed1811360936bec24d2ee0fc073c1def1098e2399fd7de76c63dca
   url: oci://ghcr.io/openebs/charts/openebs

--- a/clusters/psb/apps/rook-ceph/ceph-csi-drivers/ocirepository.yaml
+++ b/clusters/psb/apps/rook-ceph/ceph-csi-drivers/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 1.0.4
+    digest: sha256:2b71973c8c965a662e45ddd10d12fea871802ba1014b3c10a1ca2e3513c75662
   url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers

--- a/clusters/psb/apps/system-controllers/k8tz/app/ocirepository.yaml
+++ b/clusters/psb/apps/system-controllers/k8tz/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.19.0
+    digest: sha256:80070875201a6a9809c8bcdec3ead542195ed522ad2a4d33f81477fb8d9970e0
   url: oci://ghcr.io/home-operations/charts-mirror/k8tz

--- a/clusters/psb/apps/system-controllers/snapshot-controller/app/ocirepository.yaml
+++ b/clusters/psb/apps/system-controllers/snapshot-controller/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 5.2.0
+    digest: sha256:4e398ea7535735d3da18029dcad3bf488ac556525005453bb634657ad517b1ad
   url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller

--- a/clusters/psb/apps/system/descheduler/app/ocirepository.yaml
+++ b/clusters/psb/apps/system/descheduler/app/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
+    digest: sha256:b1f1d872bf64ebf88437467f4a2217bd08cf0e3cd07861e281f20b7b578d5c18
   url: oci://ghcr.io/home-operations/charts-mirror/descheduler

--- a/clusters/psb/apps/system/ksgate/app/ocirepository.yaml
+++ b/clusters/psb/apps/system/ksgate/app/ocirepository.yaml
@@ -10,4 +10,5 @@ spec:
     operation: copy
   ref:
     tag: 0.6.2
+    digest: sha256:89c2357f030a92dca37a812e2a7bff2f311fb3711cb2c09012c2bdbb3051ab69
   url: oci://ghcr.io/ksgate/charts/ksgate


### PR DESCRIPTION
## What

Pins the 19 OCI helm charts that only had `ref.tag` by adding `ref.digest` to each `ocirepository.yaml`. All digests were resolved from the live registries (ghcr.io + Azure AR) for the current `ref.tag`.

## Why

These charts were the ones Renovate's `pinDigest` kept trying to pin in the failing "pin dependencies" branch. Now that they're already pinned in git, Renovate won't attempt (and fail on) those pins - and they still update normally via version bumps, since Renovate bumps the chart tag + digest together.

## Files

19 ocirepository.yaml files across system, observability, network, rook-ceph, media, and kube-system apps (k8tz, snapshot-controller, openebs, external-dns, ceph-csi-drivers, silence-operator, grafana-operator, victoria-logs, prometheus-*, descheduler, ksgate, metrics-server, intel-gpu, cilium, immich). Each diff is a single added `digest:` line.
