### PR TITLE
fix(renovate): revert invalid helm-values regex lookahead

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "managerFilePatterns": ["/^clusters/.+\\.yaml(?:\\.j2)?$/"]
   },
   "helm-values": {
-    "managerFilePatterns": ["/^clusters/(?!psb/talos/).+\\.yaml(?:\\.j2)?$/"]
+    "managerFilePatterns": ["/^clusters/.+\\.yaml(?:\\.j2)?$/"]
   },
   "kubernetes": {
     "managerFilePatterns": ["/^clusters/.+\\.yaml(?:\\.j2)?$/"]


### PR DESCRIPTION
## Fix

Reverts the `helm-values.managerFilePatterns` value added in #1160. That pattern used a negative lookahead (`(?!psb/talos/)`) which Renovate's config validation rejects - hence issue #1162 and the halted PRs.

Restores the original valid pattern `/^clusters/.+\.yaml(?:\.j2)?$/`.

## Trade-off

The Talos `machineconfig.yaml.j2` will be parsed by the `helm-values` manager again and log a non-fatal `YAMLParseError` warning. It's cosmetic - the `kubernetes` manager still handles those files for k8s image updates, and it doesn't block anything. Renovate doesn't accept lookaheads in manager file patterns, so there's no regex-only way to exclude just that one path.
