### PR TITLE
chore(renovate): drop redundant pinDigest override

### DIFF
--- a/.renovate/overrides.json
+++ b/.renovate/overrides.json
@@ -12,23 +12,6 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["/factory\\.talos\\.dev/"],
       "overridePackageName": "ghcr.io/siderolabs/installer"
-    },
-    {
-      "description": "Disable digest pinning for images that don't resolve cleanly (date-versioned k8s/talos/flux system images) or need auth (self-hosted registries) - pinning them fails the whole pinned branch",
-      "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["pinDigest"],
-      "matchPackageNames": [
-        "registry.k8s.io/kube-apiserver",
-        "registry.k8s.io/kube-controller-manager",
-        "registry.k8s.io/kube-proxy",
-        "registry.k8s.io/kube-scheduler",
-        "ghcr.io/siderolabs/kubelet",
-        "ghcr.io/siderolabs/installer",
-        "/controlplaneio-fluxcd/",
-        "/forgejo\\.ellis\\.link/",
-        "/erwanleboucher\\.dev/"
-      ],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
The pinDigest exclusion in overrides.json was a workaround for failing 'pin dependencies' branches. Its root cause is now fixed - docker:pinDigests was removed from the base renovate-config (#58), so Renovate no longer runs pinDigest updates. The rule is dead weight; removing it. The helmfile depName and talos installer overrides stay.