### PR TITLE
fix(llmkube): use cephfs RWX model cache, drop midori pin

### DIFF
--- a/clusters/psb/apps/ai/llmkube/app/helmrelease.yaml
+++ b/clusters/psb/apps/ai/llmkube/app/helmrelease.yaml
@@ -48,6 +48,6 @@ spec:
     modelCache:
       enabled: true
       size: 100Gi
-      storageClass: ceph-block
-      accessMode: ReadWriteOnce
+      storageClass: ceph-filesystem
+      accessMode: ReadWriteMany
       mountPath: /models

--- a/clusters/psb/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/clusters/psb/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -32,15 +32,6 @@ spec:
     - --pooling
     - rank
     - --embedding
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                  - midori
   resources:
     cpu: 100m
     memory: 2Gi


### PR DESCRIPTION
The llmkube model cache was ReadWriteOnce (ceph-block), so only one node could attach it at a time. Every rollout surged a second pod that landed on a node that could not mount it, leaving it stuck in Init:0/3 - which is the qwen3-reranker alert that has been firing.

Switch the cache to ceph-filesystem (ReadWriteMany) so any node can mount /models, and drop the midori node pin that was only a workaround for the RWO single-node limit.

The cache is a download cache, so existing PVCs re-fetch the GGUF after recreation.