### PR TITLE
fix(llmkube): revert model cache to ceph-block RWO

### DIFF
--- a/clusters/psb/apps/ai/llmkube/app/helmrelease.yaml
+++ b/clusters/psb/apps/ai/llmkube/app/helmrelease.yaml
@@ -48,6 +48,6 @@ spec:
     modelCache:
       enabled: true
       size: 100Gi
-      storageClass: ceph-filesystem
-      accessMode: ReadWriteMany
+      storageClass: ceph-block
+      accessMode: ReadWriteOnce
       mountPath: /models


### PR DESCRIPTION
The cephfs model cache switch does not work on this cluster: the Talos nodes lack the ceph kernel module, so the cephfs CSI kernel mount fails (`modprobe: FATAL: Module ceph not found in directory /lib/modules/6.18.42-talos`) and the operator controller cannot start. RBD (ceph-block) mounts fine on Talos, so revert the cache to RWO ceph-block. Keep the midori pin removal from the previous change.