### PR TITLE
fix(llmkube): per-service node-local model cache on openebs-hostpath

### DIFF
--- a/clusters/psb/apps/ai/llmkube/app/helmrelease.yaml
+++ b/clusters/psb/apps/ai/llmkube/app/helmrelease.yaml
@@ -47,7 +47,13 @@ spec:
         enabled: false
     modelCache:
       enabled: true
+      # perService gives each InferenceService its own node-local cache that
+      # binds on the node its pod schedules to. WaitForFirstConsumer forces the
+      # rollout pod onto that same node, so a single-replica RWO workload never
+      # deadlocks on a second pod that cannot mount the RWO volume (the bug that
+      # kept qwen3-reranker stuck in Init:0/3).
+      mode: perService
       size: 100Gi
-      storageClass: ceph-block
+      storageClass: openebs-hostpath
       accessMode: ReadWriteOnce
       mountPath: /models


### PR DESCRIPTION
Switch the llmkube model cache from a single shared RWO ceph-block volume to per-service node-local caches on openebs-hostpath.

Why: the shared ReadWriteOnce cache plus the operator's forced rolling-update surges a second pod on every rollout that cannot mount the RWO volume already on another node, so qwen3-reranker deadlocks in Init:0/3 (the recurring alert). perService + WaitForFirstConsumer node-local storage binds each cache to the node its pod schedules on and forces the rollout pod onto that node - no cross-node RWO conflict, no node pinning.

This mirrors how the upstream llmkube homelab runs it.