### PR TITLE
fix(media): repin immich-tools image to 2b1e68c

### DIFF
--- a/clusters/psb/apps/media/immich-tools/app/cronjob.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
           containers:
             - name: sync
-              image: ghcr.io/trash-panda-v91-beta/immich-tools:7f6c917
+              image: ghcr.io/trash-panda-v91-beta/immich-tools:2b1e68c
               args:
                 - "sync-favorites"
               env:

--- a/clusters/psb/apps/media/immich-tools/app/deployment.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: watcher
-          image: ghcr.io/trash-panda-v91-beta/immich-tools:7f6c917
+          image: ghcr.io/trash-panda-v91-beta/immich-tools:2b1e68c
           args:
             - "watch-upload"
           env:


### PR DESCRIPTION
Repin `immich-tools` from `:7f6c917` to `:2b1e68c` in the favorites cronjob and the watch-upload deployment.

`:7f6c917` was never pushed to GHCR, and the image had been private, so the daily favorites sync sat in ImagePullBackOff for days and KubeJobNotCompleted fired. The package is public again and `:2b1e68c` (current main, includes the stream-to-disk fix) pulls and runs - verified with a manual job that completed in ~10s.