### PR TITLE
fix(rook-ceph): drop mgr insights module

### DIFF
--- a/clusters/psb/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/clusters/psb/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -41,8 +41,6 @@ spec:
         modules:
           - name: diskprediction_local
             enabled: true
-          - name: insights
-            enabled: true
           - name: pg_autoscaler
             enabled: true
           - name: rook


### PR DESCRIPTION
Remove the `insights` mgr module from the rook-ceph cluster config.

It leaks memory on the active mgr: it writes a `health_history` slot every ~5s and never flushes, so the mgr's working set grows ~3Gi over 46h until it hits the 4Gi cap and OOMs. The standby mgr (which does not load insights) stays flat at ~0.2Gi, confirming the module is the cause rather than a transient spike - which is why the earlier 2Gi->4Gi bump just delayed the OOM. Insights is telemetry collection not used here.