### PR TITLE
fix(rook-ceph): explicitly disable insights mgr module

### DIFF
--- a/clusters/psb/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/clusters/psb/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -41,6 +41,8 @@ spec:
         modules:
           - name: diskprediction_local
             enabled: true
+          - name: insights
+            enabled: false
           - name: pg_autoscaler
             enabled: true
           - name: rook


### PR DESCRIPTION
Keep `insights` listed in the mgr modules but with `enabled: false`.

PR #1181 removed it from the list, but Rook only enables the modules it is told about - removing one leaves it enabled, so insights stayed on. Listing it with `enabled: false` makes Rook disable it persistently. Also disabled live via `ceph mgr module disable insights`, so the leak is already stopped.