### PR TITLE
chore(immich-tools): require bearer token on the API

### DIFF
--- a/clusters/psb/apps/media/immich-tools/app/deployment.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: immich-tools
-          image: ghcr.io/trash-panda-v91-beta/immich-tools:v0.2.1
+          image: ghcr.io/trash-panda-v91-beta/immich-tools:v0.2.2
           args:
             - "serve"
           env:
@@ -36,6 +36,11 @@ spec:
                 secretKeyRef:
                   name: immich-tools-secret
                   key: pcloud_token
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: immich-tools-secret
+                  key: api_token
             - name: CONFIG
               value: /data/config.toml
             - name: STATE_DIR

--- a/clusters/psb/apps/media/immich-tools/app/externalsecret.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/externalsecret.yaml
@@ -20,3 +20,7 @@ spec:
       remoteRef:
         key: Immich pCloud OAuth Token
         property: access token
+    - secretKey: api_token
+      remoteRef:
+        key: Immich Tools
+        property: token


### PR DESCRIPTION
Bump immich-tools to `v0.2.2` (API now requires a bearer token) and wire `API_TOKEN` from the new `Immich Tools` 1Password item (`token` field).

- `deployment.yaml`: image `v0.2.2`, add `API_TOKEN` env from secret
- `externalsecret.yaml`: add `api_token` key