### PR TITLE
chore(immich-tools): bump image to v0.2.3

### DIFF
--- a/clusters/psb/apps/media/immich-tools/app/deployment.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: immich-tools
-          image: ghcr.io/trash-panda-v91-beta/immich-tools:v0.2.2
+          image: ghcr.io/trash-panda-v91-beta/immich-tools:v0.2.3
           args:
             - "serve"
           env:


### PR DESCRIPTION
Bump immich-tools to `v0.2.3` - bundles CA certs into the scratch image so the pcloud `/sync` TLS verify succeeds.