### PR TITLE
chore(immich-tools): use EU pCloud host

### DIFF
--- a/clusters/psb/apps/media/immich-tools/app/deployment.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/deployment.yaml
@@ -36,6 +36,8 @@ spec:
                 secretKeyRef:
                   name: immich-tools-secret
                   key: pcloud_token
+            - name: PCLOUD_HOST
+              value: eapi.pcloud.com
             - name: API_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Set `PCLOUD_HOST=eapi.pcloud.com` - the token is rejected on the US host (result 2094); the account is on the EU region.