### PR TITLE
chore(immich-tools): bump image to v0.2.4

### DIFF
--- a/clusters/psb/apps/media/immich-tools/app/deployment.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: immich-tools
-          image: ghcr.io/trash-panda-v91-beta/immich-tools:v0.2.3
+          image: ghcr.io/trash-panda-v91-beta/immich-tools:v0.2.4
           args:
             - "serve"
           env:


### PR DESCRIPTION
Bump immich-tools to `v0.2.4` - parses pCloud u64 file ids/hashes, so listfolder no longer fails on overflow.