### PR TITLE
chore(immich-tools): mount emptyDir at /tmp

### DIFF
--- a/clusters/psb/apps/media/immich-tools/app/deployment.yaml
+++ b/clusters/psb/apps/media/immich-tools/app/deployment.yaml
@@ -62,6 +62,8 @@ spec:
               mountPath: /data
             - name: favorites
               mountPath: /favorites
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 10m
@@ -75,3 +77,5 @@ spec:
         - name: favorites
           persistentVolumeClaim:
             claimName: immich-favorites
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
Scratch image has no /tmp - the pcloud download writes temp files to `/tmp` and fails with `failed to create temp file: No such file or directory`. Mount an `emptyDir` at `/tmp`.